### PR TITLE
Tweak whitespace to attempt to resolve web rendering issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 
 <details open>
 <summary>🎙️Top Neurodiversity Podcasts🎙️</summary>
-  
+
 * [The Late Discovered Club](https://open.spotify.com/show/52zsS8UHyyHJcYpeGDDOn0?si=1e38c63f0c44485f)
 * [ADHD Chatter by Alex Partridge](https://open.spotify.com/show/371UdLohffgSlWAEuQ55Hi?si=01ece140ee7d4fa1)
 * [The Neurodivergent Woman](https://open.spotify.com/show/42UYC0omfWNQeFt6nuVDqv?si=e6107b338ebd42b0)
+
 </details>
 
 <details open>
 <summary> Neurodivergent Creators to follow</summary>
-  
+
 * [Parul Singh - LinkedIn](https://www.linkedin.com/in/parul-parallel-minds/)
 * [Steph Jones, The Autistic Therapist on Instagram](https://www.instagram.com/autistic_therapist/?igsh=MW82ZWE1NG4yeXAxMw%3D%3D)
 * [Tumi | The Black Dyspraxic on Instagram](https://www.instagram.com/theblackdyspraxic/?igsh=eWh5NjIzNHZqd3hi)


### PR DESCRIPTION
Resolves #3 

Markdown can be picky about whitespace. These detail blocks had two spaces on the first line. I think removing the spaces and adding a blank line before the closing detail tag should help.

I imagine the web and repo Markdown renderers must be slightly different!